### PR TITLE
Add basic Flask CRM prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # CRM-INTEGRA
-PAQUETE EMPRESARIAL
+
+Un prototipo simple de CRM construido con Flask. Incluye:
+
+- Pantalla de inicio de sesión con verificación OTP.
+- Registro de usuarios.
+- Panel de control (dashboard) con tareas, clientes y proyectos.
+- Sección de perfil, gestión de tareas, clientes, proyectos y reportes.
+
+## Requisitos
+
+- Python 3
+- Dependencias en `requirements.txt`
+
+## Uso
+
+Instalar dependencias y ejecutar la aplicación:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+La aplicación estará disponible en `http://localhost:5000`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,131 @@
+from flask import Flask, render_template, redirect, url_for, request, session, flash
+from werkzeug.security import generate_password_hash, check_password_hash
+import pyotp
+
+app = Flask(__name__)
+app.secret_key = 'CHANGE_ME'
+
+# In-memory stores
+users = {}
+tasks = []
+clients = []
+projects = []
+
+
+@app.route('/')
+def index():
+    if 'user' in session:
+        return redirect(url_for('dashboard'))
+    return redirect(url_for('login'))
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        email = request.form['email']
+        password = generate_password_hash(request.form['password'])
+        otp_secret = pyotp.random_base32()
+        users[username] = {
+            'email': email,
+            'password': password,
+            'otp_secret': otp_secret,
+            'tasks': [],
+            'clients': [],
+            'projects': []
+        }
+        flash(f"OTP Secret (store in authenticator app): {otp_secret}")
+        return redirect(url_for('login'))
+    return render_template('register.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        otp = request.form['otp']
+        user = users.get(username)
+        if user and check_password_hash(user['password'], password):
+            totp = pyotp.TOTP(user['otp_secret'])
+            if totp.verify(otp):
+                session['user'] = username
+                return redirect(url_for('dashboard'))
+            else:
+                flash('Invalid OTP')
+        else:
+            flash('Invalid credentials')
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.pop('user', None)
+    return redirect(url_for('login'))
+
+
+@app.route('/dashboard')
+def dashboard():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    username = session['user']
+    user = users[username]
+    return render_template('dashboard.html', user=username, tasks=user['tasks'], clients=user['clients'], projects=user['projects'])
+
+
+@app.route('/profile')
+def profile():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    username = session['user']
+    user = users[username]
+    return render_template('profile.html', user=username, email=user['email'])
+
+
+@app.route('/tasks', methods=['GET', 'POST'])
+def manage_tasks():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    username = session['user']
+    user = users[username]
+    if request.method == 'POST':
+        task = request.form['task']
+        user['tasks'].append({'task': task, 'status': 'pending'})
+    return render_template('tasks.html', tasks=user['tasks'])
+
+
+@app.route('/clients', methods=['GET', 'POST'])
+def manage_clients():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    username = session['user']
+    user = users[username]
+    if request.method == 'POST':
+        client = request.form['client']
+        user['clients'].append({'name': client})
+    return render_template('clients.html', clients=user['clients'])
+
+
+@app.route('/projects', methods=['GET', 'POST'])
+def manage_projects():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    username = session['user']
+    user = users[username]
+    if request.method == 'POST':
+        project = request.form['project']
+        user['projects'].append({'name': project})
+    return render_template('projects.html', projects=user['projects'])
+
+
+@app.route('/reports')
+def reports():
+    if 'user' not in session:
+        return redirect(url_for('login'))
+    username = session['user']
+    user = users[username]
+    return render_template('reports.html', tasks=user['tasks'], projects=user['projects'], clients=user['clients'])
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask-login
+pyotp
+

--- a/templates/clients.html
+++ b/templates/clients.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Clientes</title>
+<h1>Clientes</h1>
+<form method="post">
+    <input type="text" name="client" placeholder="Nuevo cliente" required>
+    <button type="submit">Agregar</button>
+</form>
+<ul>
+{% for c in clients %}
+  <li>{{ c.name }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('dashboard') }}">Volver al Dashboard</a>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>Dashboard</title>
+<h1>Bienvenido {{ user }}</h1>
+<h2>Tareas</h2>
+<ul>
+{% for t in tasks %}
+  <li>{{ t.task }} - {{ t.status }}</li>
+{% endfor %}
+</ul>
+<h2>Clientes</h2>
+<ul>
+{% for c in clients %}
+  <li>{{ c.name }}</li>
+{% endfor %}
+</ul>
+<h2>Proyectos</h2>
+<ul>
+{% for p in projects %}
+  <li>{{ p.name }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('logout') }}">Cerrar sesión</a>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Login</title>
+<h1>Login</h1>
+<form method="post">
+    <label>Usuario/Email:</label>
+    <input type="text" name="username" required><br>
+    <label>Contraseña:</label>
+    <input type="password" name="password" required><br>
+    <label>OTP:</label>
+    <input type="text" name="otp" required><br>
+    <button type="submit">Iniciar sesión</button>
+</form>
+<a href="{{ url_for('register') }}">Crear cuenta</a>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<title>Perfil</title>
+<h1>Perfil de {{ user }}</h1>
+<p>Email: {{ email }}</p>
+<a href="{{ url_for('dashboard') }}">Volver al Dashboard</a>

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Proyectos</title>
+<h1>Proyectos</h1>
+<form method="post">
+    <input type="text" name="project" placeholder="Nuevo proyecto" required>
+    <button type="submit">Agregar</button>
+</form>
+<ul>
+{% for p in projects %}
+  <li>{{ p.name }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('dashboard') }}">Volver al Dashboard</a>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Registro</title>
+<h1>Crear cuenta</h1>
+<form method="post">
+    <label>Usuario:</label>
+    <input type="text" name="username" required><br>
+    <label>Email:</label>
+    <input type="email" name="email" required><br>
+    <label>Contraseña:</label>
+    <input type="password" name="password" required><br>
+    <button type="submit">Registrar</button>
+</form>
+<a href="{{ url_for('login') }}">Volver al Login</a>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>Reportes</title>
+<h1>Reportes</h1>
+<h2>Tareas</h2>
+<ul>
+{% for t in tasks %}
+  <li>{{ t.task }} - {{ t.status }}</li>
+{% endfor %}
+</ul>
+<h2>Clientes</h2>
+<ul>
+{% for c in clients %}
+  <li>{{ c.name }}</li>
+{% endfor %}
+</ul>
+<h2>Proyectos</h2>
+<ul>
+{% for p in projects %}
+  <li>{{ p.name }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('dashboard') }}">Volver al Dashboard</a>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>Tareas</title>
+<h1>Tareas</h1>
+<form method="post">
+    <input type="text" name="task" placeholder="Nueva tarea" required>
+    <button type="submit">Agregar</button>
+</form>
+<ul>
+{% for t in tasks %}
+  <li>{{ t.task }} - {{ t.status }}</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('dashboard') }}">Volver al Dashboard</a>


### PR DESCRIPTION
## Summary
- create simple Flask web app with OTP-based login
- add pages for dashboard, profile, tasks, clients, projects and reports
- document how to run the application

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6856e8b9b1ac8326b590035a133a45e8